### PR TITLE
Update requirements to fix conflict error and to use kytos-ng repo

### DIFF
--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -1,5 +1,5 @@
--e git+git://github.com/kytos/python-openflow.git#egg=python-openflow
--e git+https://github.com/kytos/kytos.git#egg=kytos
+-e git+git://github.com/kytos-ng/python-openflow.git#egg=python-openflow
+-e git+https://github.com/kytos-ng/kytos.git#egg=kytos
 -e .
 pip-tools >= 2.0
 coverage

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,8 +4,8 @@
 #
 #    pip-compile --output-file=requirements/dev.txt requirements/dev.in
 #
--e git+git://github.com/kytos/python-openflow.git#egg=python-openflow  # via -r requirements/dev.in
--e git+https://github.com/kytos/kytos.git#egg=kytos
+-e git+git://github.com/kytos-ng/python-openflow.git#egg=python-openflow  # via -r requirements/dev.in
+-e git+https://github.com/kytos-ng/kytos.git#egg=kytos
 -e .
 alabaster==0.7.12         # via sphinx
 appdirs==1.4.3            # via virtualenv
@@ -40,7 +40,7 @@ port_for==0.3.1           # via sphinx-autobuild
 py==1.8.1                 # via pytest, tox
 pycodestyle==2.5.0        # via yala
 pydocstyle==5.1.1         # via -r requirements/dev.in
-pygments==2.7.1           # via sphinx
+pygments==2.8.1           # via sphinx
 pylint==2.4.4             # via yala
 pyparsing==2.4.6          # via packaging
 pytest==5.4.1             # via -r requirements/dev.in


### PR DESCRIPTION
Fixes #1 

## Description of the Change

Update `requirements/dev.txt` and `requirements/dev.in` changing kytos with kytos-ng repo and with a new version of pygments compatible with kytos-ng/kytos.

## Release Notes

N/A